### PR TITLE
Spread the comic sans love for all

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1,5 +1,5 @@
 body {
-    font-family: "Comic Sans MS", "Comic Sans", sans-serif;
+    font-family: "Comic Sans MS", "Comic Sans", 'Indie Flower', sans-serif;
 }
 
 p + p {

--- a/public/index.html
+++ b/public/index.html
@@ -232,5 +232,6 @@
                 <a href="https://www.netlify.com/">Netlify</a>.
             </p>
         </footer>
+        <link href="https://fonts.googleapis.com/css?family=Indie+Flower" rel="stylesheet"> 
     </body>
 </html>


### PR DESCRIPTION
Linux doesn't have "comic sans ms" or "comic sans" so we fall back to a
webfont. I tried "cursive" and that didn't work on Ubuntu either so
going with a web font.

How it looks: 
![screenshot-2017-11-21 jolly code](https://user-images.githubusercontent.com/2160795/33054928-7bf5c1c0-ce4a-11e7-8327-e819e3094a42.png)

Font link: https://fonts.google.com/specimen/Indie+Flower